### PR TITLE
Feature/add in opt out for google and jp tracking cookies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -719,9 +719,6 @@ importers:
       storybook-addon-mock: 2.0.2_react-dom@17.0.2+react@17.0.2
       webpack: 5.65.0
 
-  projects/packages/plans:
-    specifiers: {}
-
   projects/packages/publicize:
     specifiers: {}
 
@@ -20447,7 +20444,7 @@ packages:
     dependencies:
       array.prototype.flat: 1.2.5
       global-cache: 1.2.1
-      react-with-styles: 3.2.3_react-dom@17.0.2+react@17.0.2
+      react-with-styles: 3.2.3
 
   /react-with-styles/3.2.3:
     resolution: {integrity: sha512-MTI1UOvMHABRLj5M4WpODfwnveHaip6X7QUMI2x6zovinJiBXxzhA9AJP7MZNaKqg1JRFtHPXZdroUC8KcXwlQ==}

--- a/projects/packages/tracking/changelog/feature-add-in-opt-out-for-google-and-jp-tracking-cookies
+++ b/projects/packages/tracking/changelog/feature-add-in-opt-out-for-google-and-jp-tracking-cookies
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Added in the jetpack_allow_tracking filter, to opt out of all tracking cookies being added

--- a/projects/packages/tracking/legacy/class-jetpack-tracks-client.php
+++ b/projects/packages/tracking/legacy/class-jetpack-tracks-client.php
@@ -66,6 +66,12 @@ class Jetpack_Tracks_Client {
 	 * @return mixed         True on success, WP_Error on failure
 	 */
 	public static function record_event( $event ) {
+
+		$allow_tracking = apply_filters( 'jetpack_allow_tracking', true );
+		if ( false === $allow_tracking ) {
+			return new \WP_Error( 'Tracking is disabled, through the jetpack_allow_tracking filter' );
+		}
+
 		if ( ! self::$terms_of_service ) {
 			self::$terms_of_service = new \Automattic\Jetpack\Terms_Of_Service();
 		}
@@ -198,9 +204,12 @@ class Jetpack_Tracks_Client {
 
 				$anon_id = 'jetpack:' . base64_encode( $binary ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 
+				$allow_tracking = apply_filters( 'jetpack_allow_tracking', true );
+
 				if ( ! headers_sent()
 					&& ! ( defined( 'REST_REQUEST' ) && REST_REQUEST )
 					&& ! ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST )
+					&& true === $allow_tracking
 				) {
 					setcookie( 'tk_ai', $anon_id );
 				}

--- a/projects/packages/tracking/legacy/class-jetpack-tracks-client.php
+++ b/projects/packages/tracking/legacy/class-jetpack-tracks-client.php
@@ -69,7 +69,7 @@ class Jetpack_Tracks_Client {
 
 		$allow_tracking = apply_filters( 'jetpack_allow_tracking', true );
 		if ( false === $allow_tracking ) {
-			return new \WP_Error( 'Tracking is disabled, through the jetpack_allow_tracking filter' );
+			return new \WP_Error( 'Tracking is disabled', 'Disabled via the "jetpack_allow_tracking" filter', 400 );
 		}
 
 		if ( ! self::$terms_of_service ) {

--- a/projects/packages/tracking/src/class-tracking.php
+++ b/projects/packages/tracking/src/class-tracking.php
@@ -86,6 +86,14 @@ class Tracking {
 			);
 		}
 
+		$allow_tracking = apply_filters( 'jetpack_allow_tracking', true );
+		if ( false === $allow_tracking ) {
+			wp_send_json_error(
+				__( 'Tracking is disabled via the jetpack_allow_tracking filter', 'jetpack-tracking' ),
+				403
+			);
+		}
+
 		$tracks_data = array();
 		if ( 'click' === $_REQUEST['tracksEventType'] && isset( $_REQUEST['tracksEventProp'] ) ) {
 			if ( is_array( $_REQUEST['tracksEventProp'] ) ) {
@@ -106,6 +114,11 @@ class Tracking {
 	 * @param boolean $enqueue Also enqueue? defaults to false.
 	 */
 	public static function register_tracks_functions_scripts( $enqueue = false ) {
+
+		$allow_tracking = apply_filters( 'jetpack_allow_tracking', true );
+		if ( false === $allow_tracking ) {
+			return;
+		}
 
 		// Register jp-tracks as it is a dependency.
 		wp_register_script(
@@ -142,6 +155,12 @@ class Tracking {
 	 * Enqueue script necessary for tracking.
 	 */
 	public function enqueue_tracks_scripts() {
+
+		$allow_tracking = apply_filters( 'jetpack_allow_tracking', true );
+		if ( false === $allow_tracking ) {
+			return;
+		}
+
 		wp_enqueue_script(
 			'jptracks',
 			Assets::get_file_url_for_environment( 'js/tracks-ajax.js', 'js/tracks-ajax.js', __FILE__ ),
@@ -170,6 +189,12 @@ class Tracking {
 	 *                                   set to false, the prefix will be 'jetpack_'.
 	 */
 	public function record_user_event( $event_type, $data = array(), $user = null, $use_product_prefix = true ) {
+
+		$allow_tracking = apply_filters( 'jetpack_allow_tracking', true );
+		if ( false === $allow_tracking ) {
+			return false;
+		}
+
 		if ( ! $user ) {
 			$user = wp_get_current_user();
 		}
@@ -203,6 +228,11 @@ class Tracking {
 	 * @return bool true for success | \WP_Error if the event pixel could not be fired
 	 */
 	public function tracks_record_event( $user, $event_name, $properties = array(), $event_timestamp_millis = false ) {
+
+		$allow_tracking = apply_filters( 'jetpack_allow_tracking', true );
+		if ( false === $allow_tracking ) {
+			return false;
+		}
 
 		// We don't want to track user events during unit tests/CI runs.
 		if ( $user instanceof \WP_User && 'wptests_capabilities' === $user->cap_key ) {
@@ -252,6 +282,12 @@ class Tracking {
 	 * @return \Jetpack_Tracks_Event|\WP_Error
 	 */
 	private function tracks_build_event_obj( $user, $event_name, $properties = array(), $event_timestamp_millis = false ) {
+
+		$allow_tracking = apply_filters( 'jetpack_allow_tracking', true );
+		if ( false === $allow_tracking ) {
+			return new \WP_Error( 'Tracking is disabled, through the jetpack_allow_tracking filter' );
+		}
+
 		$identity = $this->tracks_get_identity( $user->ID );
 
 		$properties['user_lang'] = $user->get( 'WPLANG' );
@@ -312,7 +348,8 @@ class Tracking {
 			add_user_meta( $user_id, 'jetpack_tracks_anon_id', $anon_id, false );
 		}
 
-		if ( ! isset( $_COOKIE['tk_ai'] ) && ! headers_sent() ) {
+		$allow_tracking = apply_filters( 'jetpack_allow_tracking', true );
+		if ( ! isset( $_COOKIE['tk_ai'] ) && ! headers_sent() && true === $allow_tracking ) {
 			setcookie( 'tk_ai', $anon_id );
 		}
 

--- a/projects/packages/tracking/src/class-tracking.php
+++ b/projects/packages/tracking/src/class-tracking.php
@@ -231,7 +231,7 @@ class Tracking {
 
 		$allow_tracking = apply_filters( 'jetpack_allow_tracking', true );
 		if ( false === $allow_tracking ) {
-			return false;
+			return new WP_Error( 'tracks_record_event_not_allowed', __( 'Tracks events are not allowed.', 'jetpack-tracking' ) );
 		}
 
 		// We don't want to track user events during unit tests/CI runs.

--- a/projects/plugins/jetpack/changelog/feature-add-in-opt-out-for-google-and-jp-tracking-cookies
+++ b/projects/plugins/jetpack/changelog/feature-add-in-opt-out-for-google-and-jp-tracking-cookies
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Added in the jetpack_allow_tracking filter, to opt out of all tracking cookies being added

--- a/projects/plugins/jetpack/modules/google-analytics/classes/class-jetpack-google-amp-analytics.php
+++ b/projects/plugins/jetpack/modules/google-analytics/classes/class-jetpack-google-amp-analytics.php
@@ -28,6 +28,7 @@ class Jetpack_Google_AMP_Analytics {
 	 * Checks if its AMP request, if WooCommerce is available, if there's tracking code and in tracking is enabled.
 	 */
 	public function maybe_load_hooks() {
+
 		if ( ! class_exists( 'Jetpack_AMP_Support' ) || ! Jetpack_AMP_Support::is_amp_request() ) {
 			return;
 		}
@@ -35,7 +36,6 @@ class Jetpack_Google_AMP_Analytics {
 		if ( ! class_exists( 'WooCommerce' ) ) {
 			return;
 		}
-
 		$allow_tracking = apply_filters( 'jetpack_allow_tracking', true );
 		if ( false === $allow_tracking ) {
 			return;

--- a/projects/plugins/jetpack/modules/google-analytics/classes/class-jetpack-google-amp-analytics.php
+++ b/projects/plugins/jetpack/modules/google-analytics/classes/class-jetpack-google-amp-analytics.php
@@ -36,6 +36,11 @@ class Jetpack_Google_AMP_Analytics {
 			return;
 		}
 
+		$allow_tracking = apply_filters( 'jetpack_allow_tracking', true );
+		if ( false === $allow_tracking ) {
+			return;
+		}
+
 		if ( ! Jetpack_Google_Analytics_Options::has_tracking_code() ) {
 			return;
 		}

--- a/projects/plugins/jetpack/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/projects/plugins/jetpack/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -58,6 +58,12 @@ class Jetpack_Google_Analytics_Legacy {
 	 * Called exclusively by wp_head action
 	 */
 	public function insert_code() {
+
+		$allow_tracking = apply_filters( 'jetpack_allow_tracking', true );
+		if ( false === $allow_tracking ) {
+			return;
+		}
+
 		$tracking_id = Jetpack_Google_Analytics_Options::get_tracking_code();
 		if ( empty( $tracking_id ) ) {
 			echo "<!-- Your Google Analytics Plugin is missing the tracking ID -->\r\n";

--- a/projects/plugins/jetpack/modules/google-analytics/classes/wp-google-analytics-universal.php
+++ b/projects/plugins/jetpack/modules/google-analytics/classes/wp-google-analytics-universal.php
@@ -38,6 +38,12 @@ class Jetpack_Google_Analytics_Universal {
 	}
 
 	public function wp_head() {
+
+		$allow_tracking = apply_filters( 'jetpack_allow_tracking', true );
+		if ( false === $allow_tracking ) {
+			return;
+		}
+
 		$tracking_code = Jetpack_Google_Analytics_Options::get_tracking_code();
 		if ( empty( $tracking_code ) ) {
 			echo "<!-- No tracking ID configured for Jetpack Google Analytics -->\r\n";

--- a/projects/plugins/jetpack/src/class-tracking.php
+++ b/projects/plugins/jetpack/src/class-tracking.php
@@ -88,6 +88,12 @@ class Tracking {
 	 * @access public
 	 */
 	public function jetpack_user_authorized() {
+
+		$allow_tracking = apply_filters( 'jetpack_allow_tracking', true );
+		if ( false === $allow_tracking ) {
+			return;
+		}
+
 		$user_id = get_current_user_id();
 		$anon_id = get_user_meta( $user_id, 'jetpack_tracks_anon_id', true );
 
@@ -95,12 +101,7 @@ class Tracking {
 			$this->tracking->record_user_event( '_aliasUser', array( 'anonId' => $anon_id ) );
 			delete_user_meta( $user_id, 'jetpack_tracks_anon_id' );
 
-			$allow_tracking = apply_filters( 'jetpack_allow_tracking', true );
-			if ( false === $allow_tracking ) {
-				return;
-			}
-
-			if ( ! headers_sent() && true === $allow_tracking ) {
+			if ( ! headers_sent() ) {
 				setcookie( 'tk_ai', 'expired', time() - 1000 );
 			}
 		}

--- a/projects/plugins/jetpack/src/class-tracking.php
+++ b/projects/plugins/jetpack/src/class-tracking.php
@@ -94,7 +94,13 @@ class Tracking {
 		if ( $anon_id ) {
 			$this->tracking->record_user_event( '_aliasUser', array( 'anonId' => $anon_id ) );
 			delete_user_meta( $user_id, 'jetpack_tracks_anon_id' );
-			if ( ! headers_sent() ) {
+
+			$allow_tracking = apply_filters( 'jetpack_allow_tracking', true );
+			if ( false === $allow_tracking ) {
+				return;
+			}
+
+			if ( ! headers_sent() && true === $allow_tracking ) {
 				setcookie( 'tk_ai', 'expired', time() - 1000 );
 			}
 		}

--- a/projects/plugins/jetpack/tests/php/modules/google-analytics/test-class.google-analytics.php
+++ b/projects/plugins/jetpack/tests/php/modules/google-analytics/test-class.google-analytics.php
@@ -163,4 +163,53 @@ class WP_Test_Jetpack_Google_Analytics extends WP_UnitTestCase {
 			$actual
 		);
 	}
+
+	/**
+	 * Verify that it is possible to disable google analytics via universal class adding tracking script to header with the help of a filter.
+	 */
+	public function test_can_disable_google_analytics_universal_in_header_via_filter() {
+		// Backup existing wp_head callbacks and clear.
+		$global_backup = clone $GLOBALS['wp_filter']['wp_head'];
+		unset( $GLOBALS['wp_filter']['wp_head'] );
+
+		// Set to disable Analytics via filter.
+		add_filter( 'jetpack_allow_tracking', '__return_false' );
+
+		// Add hooks and run the test.
+		new Jetpack_Google_Analytics_Universal();
+		ob_start();
+		do_action( 'wp_head' );
+		$header = ob_get_clean();
+
+		$this->assertSame( '', $header );
+
+		// Restore wp_head callbacks.
+		$GLOBALS['wp_filter']['wp_head'] = $global_backup;
+		add_filter( 'jetpack_allow_tracking', '__return_true' );
+
+	}
+
+	/**
+	 * Verify that it is possible to disable google analytics via legacy class adding tracking script to header with the help of a filter.
+	 */
+	public function test_can_disable_google_analytics_legacy_in_header_via_filter() {
+		// Backup existing wp_head callbacks and clear.
+		$global_backup = clone $GLOBALS['wp_filter']['wp_head'];
+		unset( $GLOBALS['wp_filter']['wp_head'] );
+
+		// Set to disable Analytics via filter.
+		add_filter( 'jetpack_allow_tracking', '__return_false' );
+
+		// Add hooks and run the test.
+		new Jetpack_Google_Analytics_Legacy();
+		ob_start();
+		do_action( 'wp_head' );
+		$header = ob_get_clean();
+
+		$this->assertSame( '', $header );
+
+		// Restore wp_head callbacks.
+		$GLOBALS['wp_filter']['wp_head'] = $global_backup;
+		add_filter( 'jetpack_allow_tracking', '__return_true' );
+	}
 }

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-integration.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-integration.php
@@ -28,7 +28,7 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		$timestamp = wp_next_scheduled( 'jetpack_sync_cron' );
 		// we need to check a while in the past because the task got scheduled at
 		// the beginning of the entire test run, not at the beginning of this test :)
-		$this->assertTrue( $timestamp > time()-HOUR_IN_SECONDS );
+		$this->assertTrue( $timestamp > time() - HOUR_IN_SECONDS );
 	}
 
 	function test_default_schedule_incremental_sync_cron() {
@@ -51,7 +51,7 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 	function test_schedules_full_sync_cron() {
 		Actions::init_sync_cron_jobs();
 		$timestamp = wp_next_scheduled( 'jetpack_sync_full_cron' );
-		$this->assertTrue( $timestamp > time()-HOUR_IN_SECONDS );
+		$this->assertTrue( $timestamp > time() - HOUR_IN_SECONDS );
 	}
 
 	function test_default_schedule_full_sync_cron() {
@@ -121,7 +121,7 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 
 	function test_do_not_load_sender_if_is_cron_and_cron_sync_disabled() {
 		Constants::set_constant( 'DOING_CRON', true );
-		$settings = Settings::get_settings();
+		$settings                  = Settings::get_settings();
 		$settings['sync_via_cron'] = 0;
 		Settings::update_settings( $settings );
 		Actions::$sender = null;
@@ -186,7 +186,7 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		$this->factory->post->create_many( 2 );
 		$this->sender->do_sync();
 
-		$this->assertTrue( empty(  $this->server_event_storage->get_all_events() ) );
+		$this->assertTrue( empty( $this->server_event_storage->get_all_events() ) );
 	}
 
 	function test_enable_sending_incremental_sync() {
@@ -200,7 +200,7 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		$this->factory->post->create_many( 2 );
 		$this->sender->do_sync();
 
-		$this->assertFalse( empty(  $this->server_event_storage->get_all_events() ) );
+		$this->assertFalse( empty( $this->server_event_storage->get_all_events() ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-users.php
@@ -787,6 +787,8 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 	}
 
 
+
+
 	protected function assertUsersEqual( $user1, $user2 ) {
 		// order-independent comparison
 		$user1_array = get_object_vars( $user1->data );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds in a new filter, which allows for opting out of all Google and Jetpack tracking cookies being added and various tracking methods being triggered. This will allow websites using JetPack to be GDPR compliant by using this filter in conjunction with existing Cookie plugins. 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
* [Status] Needs Privacy Updates :: this now gives the option to make Jetpack opt in with the use of the `add_filter('jetpack_allow_tracking', fn($bool) => false);` filter. by default this is still all enabled, so opt out, but can used as opt in easily
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install this version of Jetpack to any website, set up a google analytics account, and link from your jetpack installation
* Add the following to your theme or a plugin `add_filter('jetpack_allow_tracking', fn($bool) => false);`
* Clear all cookies and reload a page on the front end, none of the jetpack/wp or google analytics cookies should be added, until the filter is removed or set to true.
